### PR TITLE
Hotfix/1.14.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-meh-app",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "description": "Quickly scaffold a new Node.js project by creating a GitLab repository, setting up linting/formatting, automatic Kubernetes deployment, local dotenv ⇄ Kubernetes secrets syncing, and more.",
   "bin": "src/index.js",
   "files": [

--- a/src/templates/default/Dockerfile
+++ b/src/templates/default/Dockerfile
@@ -1,5 +1,5 @@
 # Setup
-FROM node:14-alpine AS image
+FROM node:14-alpine
 WORKDIR /usr/src/app
 
 # Install (copy from pipeline artifacts)

--- a/src/templates/default/Dockerfile
+++ b/src/templates/default/Dockerfile
@@ -7,8 +7,6 @@ COPY package.json yarn.lock ./
 FROM image AS build
 ARG VERSION
 COPY . .
-RUN yarn
-RUN yarn build --cache-bust=$VERSION
 
 # Install
 FROM image

--- a/src/templates/default/Dockerfile
+++ b/src/templates/default/Dockerfile
@@ -1,15 +1,9 @@
 # Setup
 FROM node:14-alpine AS image
 WORKDIR /usr/src/app
-COPY package.json yarn.lock ./
 
-# Copy build from artifacts
-FROM image AS build
+# Install (copy from pipeline artifacts)
 COPY . .
-
-# Install
-FROM image
-COPY --from=build /usr/src/app/build build
 RUN yarn --production
 
 # Run

--- a/src/templates/default/Dockerfile
+++ b/src/templates/default/Dockerfile
@@ -3,9 +3,8 @@ FROM node:14-alpine AS image
 WORKDIR /usr/src/app
 COPY package.json yarn.lock ./
 
-# Build
+# Copy build from artifacts
 FROM image AS build
-ARG VERSION
 COPY . .
 
 # Install

--- a/src/templates/default/Dockerfile
+++ b/src/templates/default/Dockerfile
@@ -1,9 +1,13 @@
+# Build arguments
+ARG BUILD_PATH
+ARG NODE_VERSION
+
 # Setup
-FROM node:14-alpine AS image
+FROM node:$NODE_VERSION AS image
 WORKDIR /usr/src/app
 
 # Install (copy from pipeline artifacts)
-COPY . .
+COPY $BUILD_PATH $BUILD_PATH
 RUN yarn --production
 
 # Run

--- a/src/templates/default/Dockerfile
+++ b/src/templates/default/Dockerfile
@@ -1,13 +1,9 @@
-# Build arguments
-ARG BUILD_PATH
-ARG NODE_VERSION
-
 # Setup
-FROM node:$NODE_VERSION AS image
+FROM node:14-alpine AS image
 WORKDIR /usr/src/app
 
 # Install (copy from pipeline artifacts)
-COPY $BUILD_PATH $BUILD_PATH
+COPY . .
 RUN yarn --production
 
 # Run


### PR DESCRIPTION
Verwijderen van het standaard build commando in de Dockerfile, omdat dit nu via Gitlab CI / artifacts gebeurd.